### PR TITLE
WASM support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+runner = "wasm-server-runner"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5509,9 +5509,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "serde",
@@ -5521,9 +5521,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -5548,9 +5548,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5558,9 +5558,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5571,9 +5571,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,6 @@ bevy_rapier2d = { git = "https://github.com/cscorley/bevy_rapier", branch = "mor
 ] }
 bincode = "1.3.3"
 bytemuck = { version = "1.12.3", features = ["derive"] }
-ggrs = { version = "0.9.3", features = ["sync-send", "wasm-bindgen"] }
-# ggrs = { git = "https://github.com/gschup/ggrs/", features = ["sync-send"] }
 log = "0.4"
 matchbox_socket = { version = "0.5.0", features = ["ggrs-socket"] }
 rand = "0.8.5"
@@ -59,6 +57,12 @@ tracing-subscriber = { version = "0.3.16", features = [
     "env-filter",
 ] }
 tracing-log = "0.1.3"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+ggrs = { version = "0.9.3", features = ["sync-send"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+ggrs = { version = "0.9.3", features = ["sync-send", "wasm-bindgen"] }
 
 [patch.crates-io]
 # ggrs = { git = "https://github.com/gschup/ggrs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ bevy_rapier2d = { git = "https://github.com/cscorley/bevy_rapier", branch = "mor
 ] }
 bincode = "1.3.3"
 bytemuck = { version = "1.12.3", features = ["derive"] }
-ggrs = { version = "0.9.3", features = ["sync-send"] }
+ggrs = { version = "0.9.3", features = ["sync-send", "wasm-bindgen"] }
 # ggrs = { git = "https://github.com/gschup/ggrs/", features = ["sync-send"] }
 log = "0.4"
 matchbox_socket = { version = "0.5.0", features = ["ggrs-socket"] }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Bevy GGRS Rapier example
+
 This is my quest to get GGRS and Rapier to work together in the Bevy engine,
 using the plugins.
 
@@ -19,7 +21,25 @@ Keys
 - R turn on random movement for this window
 - T turn off random movement for this window
 
-Testing
+## Building
+
+### Native
+
+From the root directory:
+
+```
+cargo run
+```
+
+### WASM
+
+From the root directory:
+
+```
+cargo run --target wasm32-unknown-unknown
+```
+
+## Testing
 
 - You can test rollbacks locally
   - On Linux, I use the included `slowmode.sh` script.


### PR DESCRIPTION
This PR adds a few small changes required to create a runnable WASM build. It also updates the README by explaining how to run the demo natively as well as from a browser. I think this is a good change since a few people on bevy's discord have mentioned that they couldn't find any ggrs/physics demos that run in a browser.

I've tested this and it works ok on a Windows machine (although not if you run one instance natively and another in-browser because of https://github.com/cscorley/bevy_ggrs_rapier_example/issues/22), however in Safari the game crashes a few seconds after loading with an out-of-bounds error coming somewhere in the render stack. I'll investigate these crashes separately.