### PR TITLE
use new bevy_math feature to enable glam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,12 +1010,12 @@ dependencies = [
  "bevy_framepace",
  "bevy_ggrs",
  "bevy_matchbox",
+ "bevy_math",
  "bevy_rapier2d",
  "bincode",
  "bytemuck",
  "console_error_panic_hook",
  "ggrs",
- "glam 0.28.0",
  "log",
  "rand",
  "serde",
@@ -1221,7 +1221,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40253578fe83a5ffe5f4fcb4dfa196b7d9c50f36dc8efaa231a53344bf4b3e57"
 dependencies = [
  "bevy_reflect",
- "glam 0.27.0",
+ "glam",
+ "libm",
  "rand",
  "serde",
  "smallvec",
@@ -1234,7 +1235,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24a1ad15685c6035e01bdc9d5ea082558ef1438e9d40d69fc552857dd7e83e71"
 dependencies = [
- "glam 0.27.0",
+ "glam",
 ]
 
 [[package]]
@@ -1294,7 +1295,7 @@ dependencies = [
  "bevy_utils",
  "downcast-rs",
  "erased-serde",
- "glam 0.27.0",
+ "glam",
  "petgraph",
  "serde",
  "smallvec",
@@ -2508,7 +2509,7 @@ checksum = "5a9299a95fa5671ddf29ecc22b00e121843a65cb9ff24911e394b4ae556baf36"
 dependencies = [
  "const_panic",
  "encase_derive",
- "glam 0.27.0",
+ "glam",
  "thiserror",
 ]
 
@@ -2974,17 +2975,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
 dependencies = [
  "bytemuck",
+ "libm",
  "rand",
  "serde",
-]
-
-[[package]]
-name = "glam"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
-dependencies = [
- "libm",
 ]
 
 [[package]]
@@ -3203,7 +3196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd6b038160f086b0a7496edae34169ae22f328793cbe2b627a5a3d8373748ec"
 dependencies = [
  "constgebra",
- "glam 0.27.0",
+ "glam",
 ]
 
 [[package]]
@@ -3832,7 +3825,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c4b5f057b303842cf3262c27e465f4c303572e7f6b0648f60e16248ac3397f4"
 dependencies = [
  "approx",
- "glam 0.27.0",
+ "glam",
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ lto = "fat"
 codegen-units = 1
 
 [features]
+default = []
 web = ["bevy_ggrs/wasm-bindgen", "ggrs/wasm-bindgen"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,12 @@ lto = "fat"
 codegen-units = 1
 
 [features]
-default = []
 web = ["bevy_ggrs/wasm-bindgen", "ggrs/wasm-bindgen"]
 
 [dependencies]
 # Prefer listing the exact bevy and bevy-adjacent versions here for clarity of what worked
 bevy = "0.14.1"
+bevy_math = { version = "0.14.1", features = ["libm"] } # Enable libm in glam dependency
 bevy-inspector-egui = "0.25.2"
 bevy_framepace = "0.17.1"
 bevy_ggrs = "0.16.0"
@@ -55,14 +55,6 @@ bevy_rapier2d = { git = "https://github.com/cscorley/bevy_rapier", branch = "mor
     "enhanced-determinism",
     "serde-serialize",
 ] }
-
-# Overriding glam for # https://github.com/cscorley/bevy_ggrs_rapier_example/issues/22
-# We have this here so we can explicitly declare the libm feature to ensure it's
-# enabled.  We still want to have this direct dependency, even though we don't
-# use glam ourselves, because we want to force on the libm feature.
-# Unfortunately, we cannot enable the feature via bevy yet, which would be
-# optimal.
-glam = { version = "0.28.0", features = ["libm"] }
 
 # Add our web-only dependencies
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,8 @@ web = ["bevy_ggrs/wasm-bindgen", "ggrs/wasm-bindgen"]
 [dependencies]
 # Prefer listing the exact bevy and bevy-adjacent versions here for clarity of what worked
 bevy = "0.14.1"
-bevy_math = { version = "0.14.1", features = ["libm"] } # Enable libm in glam dependency
+# Enable libm in glam dependency for https://github.com/cscorley/bevy_ggrs_rapier_example/issues/22
+bevy_math = { version = "0.14.1", features = ["libm"] } 
 bevy-inspector-egui = "0.25.2"
 bevy_framepace = "0.17.1"
 bevy_ggrs = "0.16.0"


### PR DESCRIPTION
accidentally added wrong version, but bevy 0.13 has a new fool-proof way of doing this (https://github.com/bevyengine/bevy/pull/11238)